### PR TITLE
feat: add DocSearch as recommended by vuepress

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -6,6 +6,10 @@ module.exports = {
   ],
   base: '/',
   themeConfig: {
+    algolia: {
+      apiKey: 'cf0e99a1a6068ecc4ed40f54869d4735',
+      indexName: 'mpvue'
+    },
     repo: 'https://github.com/mpvue/mpvue-docs',
     docsDir: 'docs',
     docsBranch: 'master',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-search). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.